### PR TITLE
Allow file globbing for oldfiles

### DIFF
--- a/repack
+++ b/repack
@@ -57,6 +57,14 @@ if [ -z "$OUTDIR" ]; then
     exit 1
 fi
 
+# Allow file glob
+OLDFILE=$( ls -1 $OLDFILE )
+
+if [ $( echo $OLDFILE | wc -w ) -gt 1 ]; then
+   echo "ERROR: More then one file found with file globbinig for oldfile."
+   exit 1
+fi
+
 if [ ! -f "$OLDFILE" ]; then
     echo "ERROR: Unknown file $OLDFILE"
     exit 1


### PR DESCRIPTION
This allows to repack tarballs which a version number.

E.g. foo-42.tar, and oldfile parameter is set to "foo-*.tar"
