### PR TITLE
Add --linux-flavours option to set the live-config kernel

### DIFF
--- a/repack
+++ b/repack
@@ -15,11 +15,12 @@ use warnings;
 
 use File::Temp qw/ tempdir /;
 use File::Path qw(make_path);
+use File::Copy qw(move copy);
 
 sub usage()
 {
     my $text = <<'END';
-Usage: repack --outdir $OUTDIR --oldfile $OLDFILE --newname $NEWNAME --newextension $NEWEXTENSION
+Usage: repack --outdir $OUTDIR --oldfile $OLDFILE --newname $NEWNAME --newextension $NEWEXTENSION --linux-flavours $NEWFLAVOUR
 END
     print $text;
     exit;
@@ -86,6 +87,10 @@ while (@ARGV) {
      } elsif ($ARGV[0] eq '--variantid') {
          shift @ARGV;
          $opt{variantid} = shift @ARGV;
+         next;
+     } elsif ($ARGV[0] eq '--linux-flavours') {
+         shift @ARGV;
+         $opt{linuxflavours} = shift @ARGV;
          next;
     } else {
         die("Unknown argument $ARGV[0]!");
@@ -154,6 +159,22 @@ if (-e "$config_file") {
     }
 
     close($fh);
+
+    if (exists $opt{linuxflavours}) {
+        open my $in, '<', $config_file or die "Unable to open $config_file ($!)";
+        open my $out, '>', "$config_file.new" or die "Unable to open $config_file.new ($!)";
+
+        while( <$in> ) {
+            s/--linux-flavours .*\\/--linux-flavours \"$opt{linuxflavours}\" \\/g;
+            print $out $_;
+        }
+
+        close $in;
+        close $out;
+
+        copy("$config_file.new", $config_file) or die "The move operation failed: $!";
+        unlink "$config_file.new";
+    }
 }
 
 system("tar -C $tmpdir -cf $opt{outdir}/$opt{newname}.$opt{newextension} $opt{newname}");

--- a/repack.service
+++ b/repack.service
@@ -25,4 +25,7 @@
     <parameter name="variantid">
         <description>A lower-case string (no spaces or other characters outside of 0–9, a–z, ".", "_" and "-"), identifying a specific variant or edition of the operating system.</description>
     </parameter>
+    <parameter name="linux-flavours">
+        <description>A string identifying the linux kernel flavour to use for the build.</description>
+    </parameter>
 </service>

--- a/t/test
+++ b/t/test
@@ -13,7 +13,7 @@ EXT="livebuild"
 OLDFILE="$OLDNAME.$EXT"
 NEWFILE="$NEWNAME.$EXT"
 
-TESTS=(test_basic test_with test_without test_with_and_without test_variant test_variantid test_variant_and_variantid)
+TESTS=(test_basic test_with test_without test_with_and_without test_variant test_variantid test_variant_and_variantid test_linux_flavours)
 
 FAILED=()
 
@@ -24,6 +24,9 @@ function setup {
   echo test-package > $TMP_DIR/$OLDNAME/config/package-lists/enabled.list.chroot
   echo test-package > $TMP_DIR/$OLDNAME/config/package-lists/disabled
   echo some-livebuild-config > $TMP_DIR/$OLDNAME/auto/config
+  echo 'lb config noauto \' >> $TMP_DIR/$OLDNAME/auto/config
+  echo '    --linux-flavours "old-one" \' >> $TMP_DIR/$OLDNAME/auto/config
+  echo '    "${@}"' >> $TMP_DIR/$OLDNAME/auto/config
   touch $TMP_DIR/$OLDNAME/{a..c}
   tar -C $TMP_DIR -cf $TMP_DIR/$OLDFILE $OLDNAME
 }
@@ -57,6 +60,17 @@ function contents_config_identical {
 function verify_config_state {
   new_file=$(tar -xvf $TMP_DIR/$NEWFILE -O $NEWNAME/auto/config)
   contains_field=$(echo $new_file | grep "$1\=\"$2\"")
+
+  if [ -n "$contains_field" ]; then
+    RESULT=1
+  else
+    RESULT=0
+  fi
+}
+
+function verify_flavours_state {
+  new_file=$(tar -xvf $TMP_DIR/$NEWFILE -O $NEWNAME/auto/config)
+  contains_field=$(echo $new_file | grep "$1 \"$2\"")
 
   if [ -n "$contains_field" ]; then
     RESULT=1
@@ -167,6 +181,16 @@ function test_variant_and_variantid {
 
   verify_config_state VARIANT_ID VARIANT_ID-NAME
   check_result 1 "$test : VARIANT_ID=\"VARIANT_ID-NAME\" should be present"
+}
+
+function test_linux_flavours {
+  (cd $TMP_DIR && $PARENTDIR/repack --outdir $TMP_DIR --oldfile $OLDFILE --newname $NEWNAME --newextension $EXT --linux-flavours "new-one")
+
+  contents_config_identical $TMP_DIR/$OLDFILE $TMP_DIR/$NEWFILE
+  check_result 0 "$test : contents should differ"
+
+  verify_flavours_state '\-\-linux-flavours' 'new-one'
+  check_result 1 "$test : --linux-flavours \"new-one\" \ should be present"
 }
 
 function summary {


### PR DESCRIPTION
Add support for modifying auto/config on the fly to set a custom
linux kernel flavours for the image.


Need this to be able to switch flavours without changing build-iso code.

@JammyStuff @DStape @jblunck